### PR TITLE
fix: unload

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -2,6 +2,12 @@
 using BepInEx.Unity.IL2CPP;
 using ChatHistory.Systems;
 using HarmonyLib;
+using Il2CppInterop.Runtime.Injection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using UnityEngine;
 using Utils.VRising.Entities;
 
 namespace ChatHistory;
@@ -10,6 +16,34 @@ namespace ChatHistory;
 
 public class Plugin : BasePlugin {
     private static Harmony harmony;
+    private static KeyBindsBehaviour keyBindsBehaviour;
+
+    private static void UnregisterKeyBindsBehaviour() {
+        if (ClassInjector.IsTypeRegisteredInIl2Cpp<KeyBindsBehaviour>()) {
+            {
+                var field = typeof(ClassInjector).GetField("InjectedTypes", BindingFlags.NonPublic | BindingFlags.Static);
+                var value = field.GetValue(null);
+                var InjectedTypes = value as HashSet<string>;
+                InjectedTypes?.Remove(typeof(KeyBindsBehaviour).FullName);
+            }
+
+            {
+                var helpersType = typeof(ClassInjector).Assembly.GetType("Il2CppInterop.Runtime.Injection.InjectorHelpers");
+                var field = helpersType.GetField("s_ClassNameLookup", BindingFlags.NonPublic | BindingFlags.Static);
+                var value = field.GetValue(null);
+                if (value is Dictionary<(string _namespace, string _class, IntPtr imagePtr), IntPtr> s_ClassNameLookup) {
+                    var type = typeof(KeyBindsBehaviour);
+                    string klass = type.Name;
+                    string namespaze = type.Namespace ?? string.Empty;
+
+                    s_ClassNameLookup.Keys.Where(key => key._class == klass && key._namespace == namespaze).ToList().ForEach(key => {
+                        s_ClassNameLookup.Remove(key);
+                    });
+                }
+            }
+        }
+    }
+
     public override void Load() {
         if (!World.IsClient) {
             return;
@@ -17,19 +51,26 @@ public class Plugin : BasePlugin {
 
         Settings.Config.Load(Config, Log, "Client");
 
-        AddComponent<KeyBindsBehaviour>();
+        UnregisterKeyBindsBehaviour();
+        keyBindsBehaviour = AddComponent<KeyBindsBehaviour>();
 
         harmony = new Harmony(MyPluginInfo.PLUGIN_GUID);
-        Utils.Logger.Log.Trace("Patching harmony");
+        Log.LogDebug("Patching harmony");
         harmony.PatchAll();
 
-        Utils.Logger.Log.Info($"Plugin {MyPluginInfo.PLUGIN_GUID} v{MyPluginInfo.PLUGIN_VERSION} client side is loaded!");
+        Log.LogInfo($"Plugin {MyPluginInfo.PLUGIN_GUID} v{MyPluginInfo.PLUGIN_VERSION} client side is loaded!");
     }
 
     public override bool Unload() {
-        harmony.UnpatchSelf();
+        if (!World.IsClient) {
+            return true;
+        }
 
-        Utils.Logger.Log.Info($"Plugin {MyPluginInfo.PLUGIN_GUID} v{MyPluginInfo.PLUGIN_VERSION} client side is unloaded!");
+        harmony.UnpatchSelf();
+        GameObject.Destroy(keyBindsBehaviour);
+        UnregisterKeyBindsBehaviour();
+
+        Log.LogInfo($"Plugin {MyPluginInfo.PLUGIN_GUID} v{MyPluginInfo.PLUGIN_VERSION} client side is unloaded!");
         return true;
     }
 }


### PR DESCRIPTION
This seems to work for me, but it likely makes the plugin more fragile as it depends on private members.
On the other hand, even if there is a problem it will only explode on unload or reload, and both would not work without this anyway so normal behavior should be unaffected